### PR TITLE
Removed no-longer-supported `_babelType` check

### DIFF
--- a/lib/rules/string-is-marked-for-translation.js
+++ b/lib/rules/string-is-marked-for-translation.js
@@ -25,12 +25,7 @@ module.exports = function(context) {
 	    		!/^[\s]+$/.test(node.value) &&
 	        	node.parent &&
 				node.parent.type.indexOf('JSX') !== -1 &&
-				node.parent.type !== 'JSXAttribute' &&
-				(
-					node._babelType === 'JSXText' ||
-					node._babelType === 'StringLiteral' ||
-					node._babelType === 'Literal'
-				)
+				node.parent.type !== 'JSXAttribute' 
 	    	) {
 				reportUnTranslatedString(node);
 	    	}


### PR DESCRIPTION
As far as I can tell, the latest eslint simply treats all of those as `Literal`.

Plugin is currently busted with latest eslint-plugin-react and eslint-plugin-babel, it is fixed with the enclosed changes.
