### PR TITLE
Only complain about untranslated texts when there's at least one letter

### DIFF
--- a/lib/rules/string-is-marked-for-translation.js
+++ b/lib/rules/string-is-marked-for-translation.js
@@ -1,3 +1,4 @@
+var unicodeRegExp = require('unicoderegexp');
 /*
 
 */
@@ -22,7 +23,7 @@ module.exports = function(context) {
     return {
         Literal: function(node) {
             if (
-                !/^[\s]+$/.test(node.value) &&
+                unicodeRegExp.letter.test(node.value) &&
                 node.parent &&
                 node.parent.type.indexOf('JSX') !== -1 &&
                 node.parent.type !== 'JSXAttribute' &&

--- a/lib/rules/string-is-marked-for-translation.js
+++ b/lib/rules/string-is-marked-for-translation.js
@@ -8,39 +8,39 @@
 // ------------------------------------------------------------------------------
 
 module.exports = function(context) {
-	function reportUnTranslatedString(node) {
-		context.report({
-			node: node,
-			message: 'Found string literal inside JSX, should be inside a <Formatted* /> component'
-		});
-	}
+    function reportUnTranslatedString(node) {
+        context.report({
+            node: node,
+            message: 'Found string literal inside JSX, should be inside a <Formatted* /> component'
+        });
+    }
 
-	// --------------------------------------------------------------------------
-	// Public
-	// --------------------------------------------------------------------------
+    // --------------------------------------------------------------------------
+    // Public
+    // --------------------------------------------------------------------------
 
-	return {
-	    Literal: function(node) {
-	    	if (
-	    		!/^[\s]+$/.test(node.value) &&
-	        	node.parent &&
-				node.parent.type.indexOf('JSX') !== -1 &&
-				node.parent.type !== 'JSXAttribute' &&
-				(
-					node._babelType === 'JSXText' ||
-					node._babelType === 'StringLiteral' ||
-					node._babelType === 'Literal'
-				)
-	    	) {
-				reportUnTranslatedString(node);
-	    	}
-	    }
+    return {
+        Literal: function(node) {
+            if (
+                !/^[\s]+$/.test(node.value) &&
+                node.parent &&
+                node.parent.type.indexOf('JSX') !== -1 &&
+                node.parent.type !== 'JSXAttribute' &&
+                (
+                    node._babelType === 'JSXText' ||
+                    node._babelType === 'StringLiteral' ||
+                    node._babelType === 'Literal'
+                )
+            ) {
+                reportUnTranslatedString(node);
+            }
+        }
 
-	};
+    };
 };
 
 module.exports.schema = [{
-	type: 'object',
-	properties: {},
-	additionalProperties: false
+    type: 'object',
+    properties: {},
+    additionalProperties: false
 }];

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5"
   },
-  "dependencies": {},
+  "dependencies": {
+    "unicoderegexp": "0.4.1"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   }

--- a/tests/lib/rules/string-is-marked-for-translation.js
+++ b/tests/lib/rules/string-is-marked-for-translation.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Catch strings that aren't marked for translation 
+ * @fileoverview Catch strings that aren't marked for translation
  * @author Rami Valta
  */
 'use strict';
@@ -24,10 +24,10 @@ ruleTester.run('string-is-marked-for-translation', rule, {
         '  render() {',
         '    return (',
         '      <div>',
-		'		<FormattedMessage id=\'asdjl\'',
-		'			description=\'asdjfl\'',
-		'			defaultMessage=\'asdasdasd\'',
-		'		/>',
+        '        <FormattedMessage id=\'asdjl\'',
+        '            description=\'asdjfl\'',
+        '            defaultMessage=\'asdasdasd\'',
+        '        />',
         '      </div>',
         '    );',
         '  }',
@@ -51,7 +51,7 @@ ruleTester.run('string-is-marked-for-translation', rule, {
       parser: 'babel-eslint',
       errors: [{message: 'Found string literal inside JSX, should be inside a <Formatted* /> component'}]
     },
-	{
+    {
       code: [
         'class Comp1 extends Component {',
         '  render() {',
@@ -64,7 +64,7 @@ ruleTester.run('string-is-marked-for-translation', rule, {
       errors: [{message: 'Found string literal inside JSX, should be inside a <Formatted* /> component'}]
     },
 
-	 {
+     {
       code: [
         'class Comp1 extends Component {',
         '  render() {',

--- a/tests/lib/rules/string-is-marked-for-translation.js
+++ b/tests/lib/rules/string-is-marked-for-translation.js
@@ -35,6 +35,17 @@ ruleTester.run('string-is-marked-for-translation', rule, {
       ].join('\n'),
       args: [1],
       parser: 'babel-eslint'
+    },
+    {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (<div>+()</div>);', // Non-letter characters should be allowed
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
     }
   ],
 
@@ -44,6 +55,18 @@ ruleTester.run('string-is-marked-for-translation', rule, {
         'class Comp1 extends Component {',
         '  render() {',
         '    return (<div>test</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint',
+      errors: [{message: 'Found string literal inside JSX, should be inside a <Formatted* /> component'}]
+    },
+    {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (<div>æøå</div>);',
         '  }',
         '}'
       ].join('\n'),


### PR DESCRIPTION
I tried adding eslint-plugin-react-intl to a project that had various "innocent" characters outside of `<FormattedMessage>`, such as parentheses, plus signs, unicode arrows, etc.

Instead of adding bogus `<FormattedMessage>` components or disabling the plugin for the files that use those, I thought it might be better to only complain about texts that contain at least one letter. At least in that project it reduced the list of lint errors to texts that we had actually forgotten to mark for translation :)

By the way, I noticed that lib/rules/string-is-marked-for-translation.js contained a mix of tab and spaces, and since index.js didn't have tabs, I assumed that you intended to use spaces :)